### PR TITLE
Add demo apps guidance

### DIFF
--- a/coding-conventions/javascript-coding-standards.md
+++ b/coding-conventions/javascript-coding-standards.md
@@ -91,6 +91,7 @@
   1. Generate minified and non-minified versions.
   2. Ensure that all generated versions export a mapping file.
 15. When including logging, use [loglevel](https://www.npmjs.com/package/loglevel).
+16. When including demo apps, use [express](https://expressjs.com/) and [ejs](https://ejs.co/) for their simplicity to help developers focus on the functionality covered.
 
 ## Code structure (functional or object-oriented)
 

--- a/coding-conventions/javascript-coding-standards.md
+++ b/coding-conventions/javascript-coding-standards.md
@@ -91,7 +91,7 @@
   1. Generate minified and non-minified versions.
   2. Ensure that all generated versions export a mapping file.
 15. When including logging, use [loglevel](https://www.npmjs.com/package/loglevel).
-16. When including demo apps, use [express](https://expressjs.com/) and [ejs](https://ejs.co/) for their simplicity to help developers focus on the functionality covered.
+16. When including a demo app with a server component, use [express](https://expressjs.com/) and if a templating engine is required, use [ejs](https://ejs.co/). The simplicity and widespread of those tools help developers focus on the functionality covered.
 
 ## Code structure (functional or object-oriented)
 


### PR DESCRIPTION
The demo apps should have a simple and consistent setup to help users of our libraries focus on our code rather than be distracted by tooling.

It is proposed that by default Express and EJS would be used.

See also: https://github.com/inrupt/solid-client-access-grants-js/pull/252